### PR TITLE
disable capitalization and autocorrection for server host input

### DIFF
--- a/TelegramUI/ProxyServerSettingsController.swift
+++ b/TelegramUI/ProxyServerSettingsController.swift
@@ -132,7 +132,7 @@ private enum ProxySettingsEntry: ItemListNodeEntry {
             case let .connectionHeader(theme, text):
                 return ItemListSectionHeaderItem(theme: theme, text: text, sectionId: self.section)
             case let .connectionServer(theme, placeholder, text):
-                return ItemListSingleLineInputItem(theme: theme, title: NSAttributedString(), text: text, placeholder: placeholder, sectionId: self.section, textUpdated: { value in
+                return ItemListSingleLineInputItem(theme: theme, title: NSAttributedString(), text: text, placeholder: placeholder, type: .regular(capitalization: false, autocorrection: false), sectionId: self.section, textUpdated: { value in
                     arguments.updateState { current in
                         var state = current
                         state.host = value


### PR DESCRIPTION
disable capitalization and autocorrection for server host input on Add Proxy screen

https://contest.dev/telegram-fixes/entry320#issue5041