### PR TITLE
Fix single archived chat ougoing call peer name displaying

### DIFF
--- a/TelegramUI/ChatListItem.swift
+++ b/TelegramUI/ChatListItem.swift
@@ -360,7 +360,7 @@ class ChatListItemNode: ItemListRevealOptionsItemNode {
                         } else {
                             result += "Outgoing message"
                         }
-                        let (_, initialHideAuthor, messageText) = chatListItemStrings(strings: item.presentationData.strings, nameDisplayOrder: item.presentationData.nameDisplayOrder, message: peer.message, chatPeer: peer.peer, accountPeerId: item.context.account.peerId)
+                        let (_, initialHideAuthor, messageText) = chatListItemStrings(strings: item.presentationData.strings, nameDisplayOrder: item.presentationData.nameDisplayOrder, message: peer.message, chatPeer: peer.peer, accountPeerId: item.context.account.peerId, isPeerGroup: false)
                         if message.flags.contains(.Incoming), !initialHideAuthor, let author = message.author, author is TelegramUser {
                             result += "\nFrom: \(author.displayTitle(strings: item.presentationData.strings, displayOrder: item.presentationData.nameDisplayOrder))"
                         }
@@ -698,7 +698,7 @@ class ChatListItemNode: ItemListRevealOptionsItemNode {
             var hideAuthor = false
             switch contentPeer {
                 case let .chat(itemPeer):
-                    let (peer, initialHideAuthor, messageText) = chatListItemStrings(strings: item.presentationData.strings, nameDisplayOrder: item.presentationData.nameDisplayOrder, message: message, chatPeer: itemPeer, accountPeerId: item.context.account.peerId, enableMediaEmoji: !enableChatListPhotos)
+                    let (peer, initialHideAuthor, messageText) = chatListItemStrings(strings: item.presentationData.strings, nameDisplayOrder: item.presentationData.nameDisplayOrder, message: message, chatPeer: itemPeer, accountPeerId: item.context.account.peerId, isPeerGroup: isPeerGroup, enableMediaEmoji: !enableChatListPhotos)
                     contentData = .chat(itemPeer: itemPeer, peer: peer, hideAuthor: hideAuthor, messageText: messageText)
                     hideAuthor = initialHideAuthor
                 case let .group(groupPeers):

--- a/TelegramUI/ChatListItemStrings.swift
+++ b/TelegramUI/ChatListItemStrings.swift
@@ -2,7 +2,7 @@ import Foundation
 import Postbox
 import TelegramCore
 
-public func chatListItemStrings(strings: PresentationStrings, nameDisplayOrder: PresentationPersonNameOrder, message: Message?, chatPeer: RenderedPeer, accountPeerId: PeerId, enableMediaEmoji: Bool = true) -> (peer: Peer?, hideAuthor: Bool, messageText: String) {
+public func chatListItemStrings(strings: PresentationStrings, nameDisplayOrder: PresentationPersonNameOrder, message: Message?, chatPeer: RenderedPeer, accountPeerId: PeerId, isPeerGroup: Bool, enableMediaEmoji: Bool = true) -> (peer: Peer?, hideAuthor: Bool, messageText: String) {
     let peer: Peer?
     
     var hideAuthor = false
@@ -115,9 +115,9 @@ public func chatListItemStrings(strings: PresentationStrings, nameDisplayOrder: 
                 case let invoice as TelegramMediaInvoice:
                     messageText = invoice.title
                 case let action as TelegramMediaAction:
-                    hideAuthor = true
                     switch action.action {
                         case let .phoneCall(_, discardReason, _):
+                            hideAuthor = !isPeerGroup
                             let incoming = message.flags.contains(.Incoming)
                             if let discardReason = discardReason {
                                 switch discardReason {
@@ -138,6 +138,7 @@ public func chatListItemStrings(strings: PresentationStrings, nameDisplayOrder: 
                                 }
                             }
                         default:
+                            hideAuthor = true
                             if let text = plainServiceMessageString(strings: strings, nameDisplayOrder: nameDisplayOrder, message: message, accountPeerId: accountPeerId) {
                                 messageText = text
                             }

--- a/TelegramUI/ChatMessageItemView.swift
+++ b/TelegramUI/ChatMessageItemView.swift
@@ -165,7 +165,7 @@ final class ChatMessageAccessibilityData {
         let authorName = item.message.author?.displayTitle
         
         if let chatPeer = item.message.peers[item.message.id.peerId] {
-            let (_, _, messageText) = chatListItemStrings(strings: item.presentationData.strings, nameDisplayOrder: item.presentationData.nameDisplayOrder, message: item.message, chatPeer: RenderedPeer(peer: chatPeer), accountPeerId: item.context.account.peerId)
+            let (_, _, messageText) = chatListItemStrings(strings: item.presentationData.strings, nameDisplayOrder: item.presentationData.nameDisplayOrder, message: item.message, chatPeer: RenderedPeer(peer: chatPeer), accountPeerId: item.context.account.peerId, isPeerGroup: false)
             
             var text = messageText
             


### PR DESCRIPTION
When a single chat was archived with the last action being an outgoing voice call, the peer name was not shown. This looked really confusing, when the cells text only displayed "You: Outgoing Call". In the Mac desktop app, the peer name is actually the only string that is shown in this situation, so this information is obviously important in this context. The fix lets you see the peer name.