### PR TITLE
Add highlighting of cell in chat list when returning to screen

### DIFF
--- a/TelegramUI/ChatListItem.swift
+++ b/TelegramUI/ChatListItem.swift
@@ -502,6 +502,17 @@ class ChatListItemNode: ItemListRevealOptionsItemNode {
         self.updateIsHighlighted(transition: (animated && !highlighted) ? .animated(duration: 0.3, curve: .easeInOut) : .immediate)
     }
     
+    override func setHighlightedPercent(_ percent: CGFloat) -> Bool {
+        guard isHighlighted else { return false }
+        
+        if percent == 0 {
+            setHighlighted(false, at: .zero, animated: true)
+        } else {
+            self.highlightedBackgroundNode.alpha = 2 * (1 - 1 / (1 + percent))
+        }
+        return isHighlighted
+    }
+    
     func updateIsHighlighted(transition: ContainedViewLayoutTransition) {
         var reallyHighlighted = self.isHighlighted
         if let item = self.item {
@@ -513,6 +524,7 @@ class ChatListItemNode: ItemListRevealOptionsItemNode {
         }
         
         if reallyHighlighted {
+            self.isHighlighted = true
             if self.highlightedBackgroundNode.supernode == nil {
                 self.insertSubnode(self.highlightedBackgroundNode, aboveSubnode: self.separatorNode)
                 self.highlightedBackgroundNode.alpha = 0.0
@@ -524,6 +536,7 @@ class ChatListItemNode: ItemListRevealOptionsItemNode {
                 self.onlineNode.setImage(PresentationResourcesChatList.recentStatusOnlineIcon(item.presentationData.theme, state: .highlighted))
             }
         } else {
+            self.isHighlighted = false
             if self.highlightedBackgroundNode.supernode != nil {
                 transition.updateAlpha(layer: self.highlightedBackgroundNode.layer, alpha: 0.0, completion: { [weak self] completed in
                     if let strongSelf = self {

--- a/TelegramUI/ChatListNode.swift
+++ b/TelegramUI/ChatListNode.swift
@@ -1419,7 +1419,28 @@ final class ChatListNode: ListView {
         
         self.forEachItemNode { itemNode in
             if let itemNode = itemNode as? ChatListItemNode {
+                _ = itemNode.setHighlightedPercent(0)
                 itemNode.updateIsHighlighted(transition: transition)
+            }
+        }
+    }
+    
+    private var nodeCurrentlyBeingAnimated: ChatListItemNode?
+    override public func updateHiglightPercent(_ percent: CGFloat) {
+        if percent == 0, let interaction = self.interaction {
+            interaction.highlightedChatLocation = nil
+        }
+        if percent == 0 || percent == 1 {
+            nodeCurrentlyBeingAnimated = nil
+        }
+        
+        if let currentlyAnimatedNode = nodeCurrentlyBeingAnimated {
+            _ = currentlyAnimatedNode.setHighlightedPercent(percent)
+        } else {
+            self.forEachItemNode { itemNode in
+                if let itemNode = itemNode as? ChatListItemNode, itemNode.setHighlightedPercent(percent) {
+                    nodeCurrentlyBeingAnimated = itemNode
+                }
             }
         }
     }


### PR DESCRIPTION
There is a good UX practice in iOS apps to leave the list cell selection on, until the user returns to the screen with the list. This helps the user to better understand the point from which his forward navigation started. A good example of this is the standard iOS Settings app (settings.mp4). So this is not a fix, but rather a UX improvement with respect to the iOS develpment best practices.

Has to be merged together with https://github.com/peter-iakovlev/Display/pull/1