### PR TITLE
Close delete button when editing is over

### DIFF
--- a/TelegramUI/CallListController.swift
+++ b/TelegramUI/CallListController.swift
@@ -246,6 +246,7 @@ public final class CallListController: ViewController {
         self.controllerNode.updateState { state in
             return state.withUpdatedEditing(false)
         }
+        self.controllerNode.dismissAllRevealOptions()
     }
     
     private func call(_ peerId: PeerId, began: (() -> Void)? = nil) {

--- a/TelegramUI/CallListControllerNode.swift
+++ b/TelegramUI/CallListControllerNode.swift
@@ -377,6 +377,10 @@ final class CallListControllerNode: ASDisplayNode {
         self.emptyStateDisposable.dispose()
     }
     
+    func dismissAllRevealOptions() {
+        listNode.dismissAllRevealOptions()
+    }
+    
     func updateThemeAndStrings(theme: PresentationTheme, strings: PresentationStrings, dateTimeFormat: PresentationDateTimeFormat, disableAnimations: Bool) {
         if theme !== self.currentState.theme || strings !== self.currentState.strings || disableAnimations != self.currentState.disableAnimations {
             switch self.mode {


### PR DESCRIPTION
There is a small UX inaccuracy in the calls list screen.
Calls -> Edit -> Tap one of the minus icons -> Tap Done
Expected behavior: The editing menu of the cell is dismissed together with the editing mode of the whole screen.
Actual behavior: The cell's editing menu is not dismissed.
This problem is present in many screens that allow editing of the list, I just made a fix for this screen.

Has to be merged together with https://github.com/peter-iakovlev/Display/pull/2