### PR TITLE
Fix jerking text on chat cell

### DIFF
--- a/TelegramUI/ChatListItem.swift
+++ b/TelegramUI/ChatListItem.swift
@@ -1524,7 +1524,7 @@ class ChatListItemNode: ItemListRevealOptionsItemNode {
             let textDeltaX = textFrame.origin.x - contentRect.origin.x
             transition.animatePositionAdditive(node: self.textNode, offset: CGPoint(x: textDeltaX, y: 0.0))
             textFrame.origin.x = contentRect.origin.x
-            self.textNode.frame = textFrame
+            transition.updateFrame(node: textNode, frame: textFrame)
             
             var contentImageFrame = self.contentImageNode.frame
             contentImageFrame.origin = textFrame.origin.offsetBy(dx: 1.0, dy: 0.0)


### PR DESCRIPTION
In production Telegram app it is possible to cause a visual glitch on the chats list screen. If you swipe to reveal the options on one of the chats, and swipe in the opposite direction while the first animation is still in progress, you can see, that the message text moves faster than the other content. The fix consolidates all content movement, so that this situation becomes impossible.