### PR TITLE
a.rychkov/contest fixes

### DIFF
--- a/TelegramUI/ChatDocumentGalleryItem.swift
+++ b/TelegramUI/ChatDocumentGalleryItem.swift
@@ -82,7 +82,7 @@ private final class ChatDocumentURLProtocol: URLProtocol {
     }
 }
 
-class ChatDocumentGalleryItemNode: GalleryItemNode, WKNavigationDelegate {
+class ChatDocumentGalleryItemNode: ZoomableContentGalleryItemNode, WKNavigationDelegate {
     fileprivate let _title = Promise<String>()
     
     private let statusNodeContainer: HighlightableButtonNode
@@ -127,9 +127,9 @@ class ChatDocumentGalleryItemNode: GalleryItemNode, WKNavigationDelegate {
         self.statusNode.isHidden = true
         
         super.init()
-        
-        self.view.addSubview(self.webView)
-        
+
+        self.view.insertSubview(self.webView, belowSubview: self.scrollNode.view)
+
         self.statusNodeContainer.addSubnode(self.statusNode)
         self.addSubnode(self.statusNodeContainer)
         

--- a/TelegramUI/ChatMessageInteractiveFileNode.swift
+++ b/TelegramUI/ChatMessageInteractiveFileNode.swift
@@ -534,7 +534,9 @@ final class ChatMessageInteractiveFileNode: ASDisplayNode {
                                 if strongSelf.waveformScrubbingNode == nil {
                                     let waveformScrubbingNode = MediaPlayerScrubbingNode(content: .custom(backgroundNode: strongSelf.waveformNode, foregroundContentNode: strongSelf.waveformForegroundNode))
                                     waveformScrubbingNode.hitTestSlop = UIEdgeInsetsMake(-10.0, 0.0, -10.0, 0.0)
-                                    waveformScrubbingNode.seek = { timestamp in
+                                    waveformScrubbingNode.seek = { timestamp, isContinuous in
+                                        guard !isContinuous else { return }
+
                                         if let strongSelf = self, let context = strongSelf.context, let message = strongSelf.message, let type = peerMessageMediaPlayerType(message) {
                                             context.sharedContext.mediaManager.playlistControl(.seek(timestamp), type: type)
                                         }

--- a/TelegramUI/ChatTextInputAttributes.swift
+++ b/TelegramUI/ChatTextInputAttributes.swift
@@ -646,7 +646,7 @@ func convertMarkdownToAttributes(_ text: NSAttributedString) -> NSAttributedStri
         while let match = regex.firstMatch(in: string as String, range: NSMakeRange(0, string.length)) {
             let matchIndex = stringOffset + match.range.location
             
-            result.append(text.attributedSubstring(from: NSMakeRange(0, match.range.location)))
+            result.append(text.attributedSubstring(from: NSMakeRange(text.length - string.length, match.range.location)))
             
             var pre = match.range(at: 3)
             if pre.location != NSNotFound {

--- a/TelegramUI/ChatVideoGalleryItemScrubberView.swift
+++ b/TelegramUI/ChatVideoGalleryItemScrubberView.swift
@@ -40,7 +40,7 @@ final class ChatVideoGalleryItemScrubberView: UIView {
         }
     }
     
-    var seek: (Double) -> Void = { _ in }
+    var seek: (_ timestamp: Double, _ isContinuous: Bool) -> Void = { _, _ in }
     
     override init(frame: CGRect) {
         self.scrubberNode = MediaPlayerScrubbingNode(content: .standard(lineHeight: 5.0, lineCap: .round, scrubberHandle: .circle, backgroundColor: UIColor(white: 1.0, alpha: 0.42), foregroundColor: .white))
@@ -57,8 +57,8 @@ final class ChatVideoGalleryItemScrubberView: UIView {
         
         super.init(frame: frame)
         
-        self.scrubberNode.seek = { [weak self] timestamp in
-            self?.seek(timestamp)
+        self.scrubberNode.seek = { [weak self] timestamp, isContinuous in
+            self?.seek(timestamp, isContinuous)
         }
         
         self.scrubberNode.playerStatusUpdated = { [weak self] status in

--- a/TelegramUI/ChatVideoGalleryItemScrubberView.swift
+++ b/TelegramUI/ChatVideoGalleryItemScrubberView.swift
@@ -163,4 +163,13 @@ final class ChatVideoGalleryItemScrubberView: UIView {
         
         self.scrubberNode.frame = CGRect(origin: CGPoint(x: scrubberInset, y: 6.0), size: CGSize(width: size.width - leftInset - rightInset - scrubberInset * 2.0, height: scrubberHeight))
     }
+
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        var hitTestRect = self.bounds
+        let minHeightDiff = 44.0 - hitTestRect.height
+        if (minHeightDiff > 0) {
+            hitTestRect = bounds.insetBy(dx: 0, dy: -minHeightDiff / 2.0)
+        }
+        return hitTestRect.contains(point)
+    }
 }

--- a/TelegramUI/InstantPageAudioNode.swift
+++ b/TelegramUI/InstantPageAudioNode.swift
@@ -127,12 +127,13 @@ final class InstantPageAudioNode: ASDisplayNode, InstantPageNode {
             }
         }
         
-        self.scrubbingNode.seek = { [weak self] timestamp in
-            if let strongSelf = self {
-                if let _ = strongSelf.playbackState {
-                    strongSelf.context.sharedContext.mediaManager.playlistControl(.seek(timestamp), type: strongSelf.playlistType)
-                }
-            }
+        self.scrubbingNode.seek = { [weak self] timestamp, isContinuous in
+            guard !isContinuous,
+                let strongSelf = self,
+                let _ = strongSelf.playbackState
+            else { return }
+
+            strongSelf.context.sharedContext.mediaManager.playlistControl(.seek(timestamp), type: strongSelf.playlistType)
         }
         
         /*if let applicationContext = account.applicationContext as? TelegramApplicationContext, let (playlistId, itemId) = instantPageAudioPlaylistAndItemIds(webpage: webpage, media: self.media) {

--- a/TelegramUI/ItemListRevealOptionsNode.swift
+++ b/TelegramUI/ItemListRevealOptionsNode.swift
@@ -140,7 +140,7 @@ private final class ItemListRevealOptionNode: ASDisplayNode {
         self.animationNode?.reset()
     }
     
-    func updateLayout(isFirst: Bool, isLeft: Bool, baseSize: CGSize, alignment: ItemListRevealOptionAlignment, isExpanded: Bool, extendedWidth: CGFloat, sideInset: CGFloat, transition: ContainedViewLayoutTransition, additive: Bool, revealFactor: CGFloat) {
+    func updateLayout(isFirst: Bool, isLeft: Bool, baseSize: CGSize, alignment: ItemListRevealOptionAlignment, isExpanded: Bool, extendedWidth: CGFloat, sideInset: CGFloat, transition: ContainedViewLayoutTransition, additive: Bool, revealFactor: CGFloat, animateIconMovement: Bool) {
         self.highlightNode.frame = CGRect(origin: CGPoint(), size: baseSize)
         
         var animateAdditive = false
@@ -163,7 +163,9 @@ private final class ItemListRevealOptionNode: ASDisplayNode {
             } else {
                 deltaX = -(previousFrame.width - backgroundFrame.width)
             }
-            transition.animatePositionAdditive(node: self.backgroundNode, offset: CGPoint(x: deltaX, y: 0.0))
+            if !animateIconMovement {
+                transition.animatePositionAdditive(node: self.backgroundNode, offset: CGPoint(x: deltaX, y: 0.0))
+            }
         } else {
             deltaX = 0.0
             transition.updateFrame(node: self.backgroundNode, frame: backgroundFrame)
@@ -185,20 +187,22 @@ private final class ItemListRevealOptionNode: ASDisplayNode {
             let titleIconSpacing: CGFloat = 11.0
             let iconFrame = CGRect(origin: CGPoint(x: contentRect.minX + floor((baseSize.width - imageSize.width + sideInset) / 2.0), y: contentRect.midY - imageSize.height / 2.0 + iconOffset), size: imageSize)
             if animateAdditive {
+                let iconOffsetX = animateIconMovement ? animationNode.frame.minX - iconFrame.minX : deltaX
                 animationNode.frame = iconFrame
-                transition.animatePositionAdditive(node: animationNode, offset: CGPoint(x: deltaX, y: 0.0))
+                transition.animatePositionAdditive(node: animationNode, offset: CGPoint(x: iconOffsetX, y: 0.0))
             } else {
                 transition.updateFrame(node: animationNode, frame: iconFrame)
             }
             
             let titleFrame = CGRect(origin: CGPoint(x: contentRect.minX + floor((baseSize.width - titleSize.width + sideInset) / 2.0), y: contentRect.midY + titleIconSpacing), size: titleSize)
             if animateAdditive {
+                let titleOffsetX = animateIconMovement ? self.titleNode.frame.minX - titleFrame.minX : deltaX
                 self.titleNode.frame = titleFrame
-                transition.animatePositionAdditive(node: self.titleNode, offset: CGPoint(x: deltaX, y: 0.0))
+                transition.animatePositionAdditive(node: self.titleNode, offset: CGPoint(x: titleOffsetX, y: 0.0))
             } else {
                 transition.updateFrame(node: self.titleNode, frame: titleFrame)
             }
-            
+
             if (abs(revealFactor) >= 0.4) {
                 animationNode.play()
             } else if abs(revealFactor) < CGFloat.ulpOfOne && !transition.isAnimated {
@@ -209,24 +213,27 @@ private final class ItemListRevealOptionNode: ASDisplayNode {
             let titleIconSpacing: CGFloat = 11.0
             let iconFrame = CGRect(origin: CGPoint(x: contentRect.minX + floor((baseSize.width - imageSize.width + sideInset) / 2.0), y: contentRect.midY - imageSize.height / 2.0 + iconOffset), size: imageSize)
             if animateAdditive {
+                let iconOffsetX = animateIconMovement ? iconNode.frame.minX - iconFrame.minX : deltaX
                 iconNode.frame = iconFrame
-                transition.animatePositionAdditive(node: iconNode, offset: CGPoint(x: deltaX, y: 0.0))
+                transition.animatePositionAdditive(node: iconNode, offset: CGPoint(x: iconOffsetX, y: 0.0))
             } else {
                 transition.updateFrame(node: iconNode, frame: iconFrame)
             }
             
             let titleFrame = CGRect(origin: CGPoint(x: contentRect.minX + floor((baseSize.width - titleSize.width + sideInset) / 2.0), y: contentRect.midY + titleIconSpacing), size: titleSize)
             if animateAdditive {
+                let titleOffsetX = animateIconMovement ? self.titleNode.frame.minX - titleFrame.minX : deltaX
                 self.titleNode.frame = titleFrame
-                transition.animatePositionAdditive(node: self.titleNode, offset: CGPoint(x: deltaX, y: 0.0))
+                transition.animatePositionAdditive(node: self.titleNode, offset: CGPoint(x: titleOffsetX, y: 0.0))
             } else {
                 transition.updateFrame(node: self.titleNode, frame: titleFrame)
             }
         } else {
             let titleFrame = CGRect(origin: CGPoint(x: contentRect.minX + floor((baseSize.width - titleSize.width + sideInset) / 2.0), y: contentRect.minY + floor((baseSize.height - titleSize.height) / 2.0)), size: titleSize)
             if animateAdditive {
+                let titleOffsetX = animateIconMovement ? self.titleNode.frame.minX - titleFrame.minX : deltaX
                 self.titleNode.frame = titleFrame
-                transition.animatePositionAdditive(node: self.titleNode, offset: CGPoint(x: deltaX, y: 0.0))
+                transition.animatePositionAdditive(node: self.titleNode, offset: CGPoint(x: titleOffsetX, y: 0.0))
             } else {
                 transition.updateFrame(node: self.titleNode, frame: titleFrame)
             }
@@ -355,7 +362,6 @@ final class ItemListRevealOptionsNode: ASDisplayNode {
         while i >= 0 && i < self.optionNodes.count {
             let node = self.optionNodes[i]
             let nodeWidth = i == (self.optionNodes.count - 1) ? lastNodeWidth : basicNodeWidth
-            let defaultAlignment: ItemListRevealOptionAlignment = self.isLeft ? .right : .left
             var nodeTransition = transition
             var isExpanded = false
             if (self.isLeft && i == 0) || (!self.isLeft && i == self.optionNodes.count - 1) {
@@ -364,7 +370,7 @@ final class ItemListRevealOptionsNode: ASDisplayNode {
                 }
             }
             if let _ = node.alignment, node.isExpanded != isExpanded {
-                nodeTransition = transition.isAnimated ? transition : .animated(duration: 0.2, curve: .spring)
+                nodeTransition = transition.isAnimated ? transition : .animated(duration: 0.2, curve: .easeInOut)
                 if !transition.isAnimated {
                     self.tapticAction()
                 }
@@ -393,9 +399,19 @@ final class ItemListRevealOptionsNode: ASDisplayNode {
             transition.updateFrame(node: node, frame: CGRect(origin: CGPoint(x: nodeLeftOffset, y: 0.0), size: CGSize(width: extendedWidth, height: size.height)), completion: { _ in
                 completionCount -= 1
                 intermediateCompletion()
-
             })
-            node.updateLayout(isFirst: (self.isLeft && i == 0) || (!self.isLeft && i == self.optionNodes.count - 1), isLeft: self.isLeft, baseSize: CGSize(width: nodeWidth, height: size.height), alignment: defaultAlignment, isExpanded: isExpanded, extendedWidth: extendedWidth, sideInset: sideInset, transition: nodeTransition, additive: !transition.isAnimated, revealFactor: revealFactor)
+            var nodeAlignment: ItemListRevealOptionAlignment
+            if (self.optionNodes.count > 1) {
+                nodeAlignment = self.isLeft ? .right : .left
+            } else {
+                if (self.isLeft) {
+                    nodeAlignment = isExpanded ? .right : .left
+                } else {
+                    nodeAlignment = isExpanded ? .left : .right
+                }
+            }
+            let animateIconMovement = self.optionNodes.count == 1
+            node.updateLayout(isFirst: (self.isLeft && i == 0) || (!self.isLeft && i == self.optionNodes.count - 1), isLeft: self.isLeft, baseSize: CGSize(width: nodeWidth, height: size.height), alignment: nodeAlignment, isExpanded: isExpanded, extendedWidth: extendedWidth, sideInset: sideInset, transition: nodeTransition, additive: !transition.isAnimated, revealFactor: revealFactor, animateIconMovement: animateIconMovement)
             
             if self.isLeft {
                 i -= 1

--- a/TelegramUI/MediaPlayerScrubbingNode.swift
+++ b/TelegramUI/MediaPlayerScrubbingNode.swift
@@ -715,30 +715,19 @@ final class MediaPlayerScrubbingNode: ASDisplayNode {
     }
     
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        var hitBounds = self.bounds
-        let hitTestSlop = self.hitTestSlop
-        hitBounds.origin.x += hitTestSlop.left
-        hitBounds.origin.y += hitTestSlop.top
-        hitBounds.size.width += -hitTestSlop.left - hitTestSlop.right
-        hitBounds.size.height += -hitTestSlop.top - hitTestSlop.bottom
-        
-        if hitBounds.contains(point) {
-            switch self.contentNodes {
-                case let .standard(node):
-                    if let handleNodeContainer = node.handleNodeContainer, handleNodeContainer.isUserInteractionEnabled {
-                        return handleNodeContainer.view
-                    } else {
-                        return nil
-                    }
-                case let .custom(node):
-                    if let handleNodeContainer = node.handleNodeContainer, handleNodeContainer.isUserInteractionEnabled {
-                        return handleNodeContainer.view
-                    } else {
-                        return nil
-                    }
-            }
-        } else {
-            return nil
+        switch self.contentNodes {
+            case let .standard(node):
+                if let handleNodeContainer = node.handleNodeContainer, handleNodeContainer.isUserInteractionEnabled {
+                    return handleNodeContainer.view
+                } else {
+                    return nil
+                }
+            case let .custom(node):
+                if let handleNodeContainer = node.handleNodeContainer, handleNodeContainer.isUserInteractionEnabled {
+                    return handleNodeContainer.view
+                } else {
+                    return nil
+                }
         }
     }
 }

--- a/TelegramUI/OverlayPlayerControlsNode.swift
+++ b/TelegramUI/OverlayPlayerControlsNode.swift
@@ -284,8 +284,8 @@ final class OverlayPlayerControlsNode: ASDisplayNode {
             }
         })
         
-        self.scrubberNode.seek = { [weak self] value in
-            self?.control?(.seek(value))
+        self.scrubberNode.seek = { [weak self] timestamp, isContinuous in
+            self?.control?(.seek(timestamp))
         }
         
         self.collapseNode.addTarget(self, action: #selector(self.collapsePressed), forControlEvents: .touchUpInside)

--- a/TelegramUI/UniversalVideoGalleryItem.swift
+++ b/TelegramUI/UniversalVideoGalleryItem.swift
@@ -163,6 +163,7 @@ final class UniversalVideoGalleryItemNode: ZoomableContentGalleryItemNode {
     private var validLayout: (ContainerViewLayout, CGFloat)?
     private var didPause = false
     private var isPaused = true
+    private var isPausedDuringSeek = false
     private var dismissOnOrientationChange = false
     private var keepSoundOnDismiss = false
     
@@ -197,8 +198,21 @@ final class UniversalVideoGalleryItemNode: ZoomableContentGalleryItemNode {
         
         super.init()
         
-        self.scrubberView.seek = { [weak self] timecode in
-            self?.videoNode?.seek(timecode)
+        self.scrubberView.seek = { [weak self] timecode, isContinuous in
+            guard let strongSelf = self else { return }
+
+            if isContinuous {
+                if !strongSelf.isPaused {
+                    strongSelf.isPausedDuringSeek = true
+                    strongSelf.videoNode?.pause()
+                }
+            } else if strongSelf.isPausedDuringSeek {
+                strongSelf.isPausedDuringSeek = false
+                if strongSelf.isPaused {
+                    strongSelf.videoNode?.play()
+                }
+            }
+            strongSelf.videoNode?.seek(timecode)
         }
         
         self.statusButtonNode.addSubnode(self.statusNode)


### PR DESCRIPTION
1. Bug. The message with Markdown tags sent from iOS can be corrupted.

Technical description: There is a mistake in Markdown parsing algorithm. The text from the beginning is pasted between tags. I fixed the mistake.

2. Bug or improvement. A bug from contest platform. User can't continuously seek the video.

Technical description: First of all, we can't perform seek instantly for performance and traffic sake. So we need to debounce seeking. I found there are 4 types of video nodes and universal one that can play a video item. All of them use the same scrubber view. I've decided to put debounce logic in the scrubber class because it already contains some (It decides not to send seek events on scrub updates). Then, we must pause the video during the seeking until the user lifts his finger. I suppose the video item would be the right place for this logic, not the view.

Remarks: 
1) I've chosen debounce over throttling for seeking because throttling could produce outdated frames which are confusing.
2) Altough I did the fix, personally I'd prefer to do it way like YouTube does. When user starts seeking, the player shows preview and continues playing. But it requires more time and, highly desirable, backend support for the best UX.

3.  Bug. It's hard to touch the video seek control.

Technical description: Control's touch area height is only 34 points. I extended it.

4. Bug or improvement. Swipe controls in the iOS app have bad UX.

-  Animation is too fast so its hard to follow. It stands out of the rest of animations.
- There is no pan selection confirmation for 1 option for non-taptic devices. User can't get the point when he selects the option.
- When option is selected by long pan, it jiggles a little. Mostly visible with 1 option available.

Technical description: A spring animation causes the option to jiggle unnaturally. I've replaced the animation timing, added icon and text animation for cases then there is only 1 option (like native iOS Mail app). It also affects and fixed multiple options animation.

5. Bug. Can't close image item (loaded as file) in gallery by swiping it if its not loaded. Also side swipes stop working after user tries to close the file once.

Technical description: I've decided to make document item class subclass of Zoomable item in order to get UIScrollView for closing scroll mechanism to work.